### PR TITLE
Patch 2

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -21,7 +21,7 @@ class Factory
 {
     private array $rules = [];
     private MessageBag $messages;
-    public string $ruleAttributeSeparator;
+    public string $ruleAttributeSeparator = ':';
 
     public function __construct($ruleAttributeSeparator = null)
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -21,13 +21,19 @@ class Factory
 {
     private array $rules = [];
     private MessageBag $messages;
+    public string $ruleAttributeSeparator;
 
-    public function __construct()
+    public function __construct($ruleAttributeSeparator = null)
     {
         $this->messages = new MessageBag();
 
         $this->registerDefaultRules();
         $this->registerDefaultMessages();
+        
+        if(!empty($ruleAttributeSeparator))
+        {
+            $this->ruleAttributeSeparator = $ruleAttributeSeparator;
+        }
     }
 
     public function __invoke(string $rule, ...$args): Rule

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -144,7 +144,7 @@ class Validation
             }
 
             if (is_string($i) && is_scalar($rule)) {
-                $rule = sprintf('%s:%s', $i, $rule);
+                $rule = sprintf('%s'.$this->factory->ruleAttributeSeparator.'%s', $i, $rule);
             }
 
             if (is_string($rule)) {
@@ -166,7 +166,7 @@ class Validation
 
     protected function parseRule(string $rule): array
     {
-        $exp      = explode(':', $rule, 2);
+        $exp      = explode($this->factory->ruleAttributeSeparator, $rule, 2);
         $ruleName = $exp[0];
 
         if (in_array($ruleName, ['matches', 'regex'])) {


### PR DESCRIPTION
With this PR i make it possible to change the default separator which used when rule has multiple attributes. For some rules, it is required to use the : in die rule and not as separator.

After merge this PR, the Factory get a new variable, which define the current separator.

Kind regards