### PR TITLE
Improve date validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,13 @@ The field under this rule must be one of `'on'`, `'yes'`, `'1'`, `'true'` (the s
 
 The field under this rule must be a date after the given minimum.
 
-The parameter should be any valid string that can be parsed by `strtotime`. For example:
+The parameter should be any valid string that can be parsed by `strtotime` including unix timestamps. For example:
 
 * after:next week
 * after:2016-12-31
 * after:2016
 * after:2016-12-31 09:56:02
+* after:1583946133
 
 </details>
 

--- a/src/Rules/Behaviours/CanValidateDates.php
+++ b/src/Rules/Behaviours/CanValidateDates.php
@@ -6,7 +6,7 @@ use Somnambulist\Components\Validation\Exceptions\ParameterException;
 
 trait CanValidateDates
 {
-    protected function assertDate(string $date): void
+    protected function assertDate(int|string $date): void
     {
         if ($this->getTimeStamp($date) === null) {
             throw ParameterException::invalidDate($date);

--- a/src/Rules/Behaviours/CanValidateDates.php
+++ b/src/Rules/Behaviours/CanValidateDates.php
@@ -8,18 +8,22 @@ trait CanValidateDates
 {
     protected function assertDate(string $date): void
     {
-        if (!$this->isValidDate($date)) {
+        if ($this->getTimeStamp($date) === null) {
             throw ParameterException::invalidDate($date);
         }
     }
 
-    protected function isValidDate(string $date): bool
+    protected function getTimeStamp(int|string $date): ?int
     {
-        return (strtotime($date) !== false);
-    }
+        if (is_int($date)) {
+            return $date;
+        }
 
-    protected function getTimeStamp($date): int
-    {
-        return strtotime($date);
+        if (is_string($date) && is_numeric($date)) {
+            return (int)$date;
+        }
+
+        $timestamp = strtotime($date);
+        return $timestamp !== false ? $timestamp : null;
     }
 }

--- a/tests/Rules/AfterTest.php
+++ b/tests/Rules/AfterTest.php
@@ -58,7 +58,8 @@ class AfterTest extends TestCase
             [$now->format("Y m d")],
             [$now->format("Y m d h:i:s")],
             ["tommorow"], //typo
-            ["lasst year"] //typo
+            ["lasst year"], //typo
+            ["0123"] //invalid unix
         ];
     }
 
@@ -72,7 +73,8 @@ class AfterTest extends TestCase
             [$now->format("Y-m-d h:i:s")],
             ["now"],
             ["tomorrow"],
-            ["2 years ago"]
+            ["2 years ago"],
+            ["1741716133"]
         ];
     }
 

--- a/tests/Rules/BeforeTest.php
+++ b/tests/Rules/BeforeTest.php
@@ -40,7 +40,8 @@ class BeforeTest extends TestCase
             [$now->format("Y-m-d h:i:s")],
             ["now"],
             ["tomorrow"],
-            ["2 years ago"]
+            ["2 years ago"],
+            ["1741716133"]
         ];
     }
 
@@ -64,7 +65,8 @@ class BeforeTest extends TestCase
             [$now->format("Y m d")],
             [$now->format("Y m d h:i:s")],
             ["tommorow"], //typo
-            ["lasst year"] //typo
+            ["lasst year"], //typo
+            ["0123"] //invalid unix
         ];
     }
 


### PR DESCRIPTION
With this change, a Unix timestamp can also be entered in the validation. This is then recognized as valid and is not changed. The After and Before rules continue to work. The advantage is that date formats can be compared even more flexibly.