### PR TITLE
Fix deprecation with accessing array with null key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['8.2', '8.3', '8.4']
+                php-version: ['8.2', '8.3', '8.4', '8.5']
 
         steps:
             - uses: actions/checkout@v4

--- a/src/Validation.php
+++ b/src/Validation.php
@@ -340,7 +340,9 @@ class Validation
 
     protected function resolveAttributeName(Attribute $attribute): string
     {
-        return $this->aliases[$attribute->key()] ?? $this->aliases[$attribute->parent()?->key()] ?? $attribute->key();
+        return $this->aliases[$attribute->key()]
+            ?? $this->aliases[$attribute->parent()?->key() ?? '']
+            ?? $attribute->key();
     }
 
     protected function resolveMessage(Attribute $attribute, Rule $rule, mixed $value): ErrorMessage

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -17,7 +17,11 @@ class ValidationTest extends TestCase
     {
         $class  = new ReflectionClass(Validation::class);
         $method = $class->getMethod('parseRule');
-        $method->setAccessible(true);
+
+        // Deprecated in PHP 8.5
+        if (PHP_VERSION_ID < 80500) {
+            $method->setAccessible(true);
+        }
 
         $validation = new Validation(new Factory(), [], []);
 


### PR DESCRIPTION
PHP 8.5+, using null as an array offset is deprecated.

When the attribute parent is null it was accessing the $this->aliases array with key null `$this->aliases[null]`

Source: https://www.php.net/releases/8.5/en.php