### PR TITLE
Fix PHP 8.5 null array offset deprecation warning

### DIFF
--- a/src/Validation.php
+++ b/src/Validation.php
@@ -340,7 +340,7 @@ class Validation
 
     protected function resolveAttributeName(Attribute $attribute): string
     {
-        return $this->aliases[$attribute->key()] ?? $this->aliases[$attribute->parent()?->key()] ?? $attribute->key();
+        return $this->aliases[$attribute->key()] ?? ($attribute->parent() ? $this->aliases[$attribute->parent()->key()] : null) ?? $attribute->key();
     }
 
     protected function resolveMessage(Attribute $attribute, Rule $rule, mixed $value): ErrorMessage


### PR DESCRIPTION
This is similar to https://github.com/somnambulist-tech/validation/pull/41, but only changing one thing, and with slightly different semantics; I prefer not to null-coalesce the associative array index to `''`.

The line could be split up, but I thought it best to retain existing project style.